### PR TITLE
Fix --shell-options in run_wasm

### DIFF
--- a/tools/run_wasm
+++ b/tools/run_wasm
@@ -41,7 +41,7 @@ while [ $# -gt 0 ]; do
       ;;
 
     --shell-option=*)
-      SHELL_OPTIONS+=" ${1#--shell-option=}"
+      SHELL_OPTIONS+=("${1#--shell-option=}")
       shift
       ;;
 
@@ -63,4 +63,4 @@ while [ $# -gt 0 ]; do
   esac
 done
 
-exec "$SHELL_BIN" $SHELL_OPTIONS "$RUN_WASM" $SHELL_ARG_SEPERATOR "$MJS_FILE" "$WASM_FILE" -- "$@"
+exec "$SHELL_BIN" "${SHELL_OPTIONS[@]}" "$RUN_WASM" $SHELL_ARG_SEPERATOR "$MJS_FILE" "$WASM_FILE" -- "$@"


### PR DESCRIPTION
Hi Martin: Not a bash expert, but seems `SHELL_OPTIONS` was never used before and didn't work locally for me.